### PR TITLE
Bump jetty.version from 9.4.9.v20180320 to 9.4.26.v20200117

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -17,7 +17,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
 
-        <jetty.version>9.4.9.v20180320</jetty.version>
+        <jetty.version>9.4.26.v20200117</jetty.version>
         <slf4j.version>1.7.25</slf4j.version>
         <lombok.version>1.18.10</lombok.version>
         <testng.version>6.10</testng.version>


### PR DESCRIPTION
Bumps `jetty.version` from 9.4.9.v20180320 to 9.4.26.v20200117.

Updates `jetty-server` from 9.4.9.v20180320 to 9.4.26.v20200117
- [Release notes](https://github.com/eclipse/jetty.project/releases)
- [Commits](https://github.com/eclipse/jetty.project/compare/jetty-9.4.9.v20180320...jetty-9.4.26.v20200117)

Updates `jetty-proxy` from 9.4.9.v20180320 to 9.4.26.v20200117
- [Release notes](https://github.com/eclipse/jetty.project/releases)
- [Commits](https://github.com/eclipse/jetty.project/compare/jetty-9.4.9.v20180320...jetty-9.4.26.v20200117)

Updates `jetty-servlet` from 9.4.9.v20180320 to 9.4.26.v20200117
- [Release notes](https://github.com/eclipse/jetty.project/releases)
- [Commits](https://github.com/eclipse/jetty.project/compare/jetty-9.4.9.v20180320...jetty-9.4.26.v20200117)

Signed-off-by: dependabot[bot] <support@github.com>